### PR TITLE
Injecting into remote processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this changelog file.
 
+## [Unreleased]
+### Added
+- Support for remote Frida server
+
 ## [1.0] - 2023-12-01
 ### Added
 - WinSock, OpenSSL and SChannel libraries

--- a/README.md
+++ b/README.md
@@ -93,12 +93,16 @@ deluder attach -i petep 12501
 deluder attach -s schannel,openssl -i log 12000
 deluder attach -c config.json "Application.exe"
 
-# Attach to existing process in a remote host (10.0.0.1 on port 12345) 
-deluder -H 10.0.0.1:12345 attach -c config.json 12501
-deluder -H 10.0.0.1:12345 attach -i petep 12501 -H 10.0.0.1
-deluder -H 10.0.0.1:12345 attach -s schannel,openssl -i log 12000
-deluder -H 10.0.0.1:12345 attach -c config.json "Application.exe"
+# Run process and attach to it in a remote host (10.0.0.1 on port 27042) 
+deluder run -r 10.0.0.1:27042 -c config.json "C:/Application.exe"
+deluder run -r 10.0.0.1:27042 -i petep "C:/Application.exe"
+deluder run --remote 10.0.0.1:27042 --debug --interceptors log,proxifier,log --scripts schannel,openssl "C:/Application.exe"
 
+# Attach to existing process in a remote host (10.0.0.1 on port 27042) 
+deluder attach -r 10.0.0.1:27042 -c config.json 12501
+deluder attach -r 10.0.0.1:27042 -i petep 12501
+deluder attach -r 10.0.0.1:27042 -s schannel,openssl -i log 12000
+deluder attach -r 10.0.0.1:27042 -c config.json "Application.exe"
 ```
 
 Both attach and run have the following parameters:
@@ -106,6 +110,7 @@ Both attach and run have the following parameters:
 - **-d/--debug** - Enables debug with verbose output
 - **-i/--interceptors [proxifier,log,log]** - Enables given interceptors
 - **-s/--scripts [winsock,openssl]** - Enables given scripts (networking libraries)
+- **-r/--remote [ip:port]** - Uses remote frida-server host
 - **--ignore-child-processes** - Disables automatic child process hooking
 
 #### Recommended Usage
@@ -210,6 +215,21 @@ Each interceptor module has important methods:
 
 The most important method for you will be the `intercept` method, in which you 
 can process the traffic. The message parameter is mutable and you can modify the data inside.
+
+## Remote Host 
+In order to intercept network communication of applications on remote hosts, on which you cannot run the deluder and PETEP itself, 
+you can use Frida server, to which you can connect from Deluder.
+
+See [Frida Releases](https://github.com/frida/frida/releases) and download frida-server for your platform. Once you run the frida-server, you can use Deluder's `-r` parameter to execute the attach/run commands on the remote machine. 
+
+For example, on remote machine, you can run:
+```shell
+frida-server -l 0.0.0.0:27042
+```
+and then run the following on your local machine:
+```shell
+deluder run -r REMOTE_IP:27042 -i log "C:/Application.exe"
+```
 
 ## Script Modules
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ deluder attach -c config.json 12501
 deluder attach -i petep 12501
 deluder attach -s schannel,openssl -i log 12000
 deluder attach -c config.json "Application.exe"
+
+# Attach to existing process in a remote host (10.0.0.1 on port 12345) 
+deluder -H 10.0.0.1:12345 attach -c config.json 12501
+deluder -H 10.0.0.1:12345 attach -i petep 12501 -H 10.0.0.1
+deluder -H 10.0.0.1:12345 attach -s schannel,openssl -i log 12000
+deluder -H 10.0.0.1:12345 attach -c config.json "Application.exe"
+
 ```
 
 Both attach and run have the following parameters:

--- a/deluder/__main__.py
+++ b/deluder/__main__.py
@@ -15,6 +15,7 @@ def main():
     """
     config = create_default_config()
 
+    host = ""
 
     def command_config():
         example_config = {
@@ -67,6 +68,9 @@ def main():
 
     parser.add_argument('--version', '-v', version=f'Deluder v{Deluder.version()}', action='version')
 
+    parser.add_argument('--host', '-H', metavar='<host:port>',
+                            help=f'Connect to an existing process in a remote host running frida-server')
+    
     # Create command parsers
     commands = parser.add_subparsers(dest='command', metavar='<command>')
 
@@ -133,14 +137,17 @@ def main():
     if args.ignore_child_processes:
         config.ignore_child_processes = True
 
+    if args.host:
+        host = args.host
+
     # Create deluder
     if args.command == 'run':
         deluder = Deluder.for_new_app(app_path=args.path, config=config)
     elif args.command == 'attach':
         if str.isdigit(args.pid_or_name):
-            deluder = Deluder.for_existing_process_id(int(args.pid_or_name), config=config)
+            deluder = Deluder.for_existing_process_id(int(args.pid_or_name), config=config, host=host)
         else:
-            deluder = Deluder.for_existing_process_name(args.pid_or_name, config=config)
+            deluder = Deluder.for_existing_process_name(args.pid_or_name, config=config, host=host)
 
     # Run deluder
     deluder.delude()

--- a/deluder/__main__.py
+++ b/deluder/__main__.py
@@ -15,8 +15,6 @@ def main():
     """
     config = create_default_config()
 
-    host = ""
-
     def command_config():
         example_config = {
             'debug': config.debug,
@@ -42,6 +40,9 @@ def main():
 
 
     def add_common_arguments(parser: argparse.ArgumentParser):
+        parser.add_argument('--remote', '-r', metavar='<host:port>',
+                            help=f'Execute deluder commands on a remote host running frida-server')
+        
         parser.add_argument('--debug', '-d', action='store_true', default=config.debug,
                             help='Enable debug mode with verbose output')
         
@@ -67,9 +68,6 @@ def main():
     )
 
     parser.add_argument('--version', '-v', version=f'Deluder v{Deluder.version()}', action='version')
-
-    parser.add_argument('--host', '-H', metavar='<host:port>',
-                            help=f'Connect to an existing process in a remote host running frida-server')
     
     # Create command parsers
     commands = parser.add_subparsers(dest='command', metavar='<command>')
@@ -88,6 +86,9 @@ def main():
 
     # Parse arguments
     args = parser.parse_args()
+    
+    # Remote host
+    remote_host = None
 
     if args.command is None:
         parser.print_help()
@@ -137,17 +138,17 @@ def main():
     if args.ignore_child_processes:
         config.ignore_child_processes = True
 
-    if args.host:
-        host = args.host
+    if args.remote:
+        remote_host = args.remote
 
     # Create deluder
     if args.command == 'run':
-        deluder = Deluder.for_new_app(app_path=args.path, config=config)
+        deluder = Deluder.for_new_app(app_path=args.path, remote_host=remote_host, config=config)
     elif args.command == 'attach':
         if str.isdigit(args.pid_or_name):
-            deluder = Deluder.for_existing_process_id(int(args.pid_or_name), config=config, host=host)
+            deluder = Deluder.for_existing_process_id(int(args.pid_or_name), remote_host=remote_host, config=config)
         else:
-            deluder = Deluder.for_existing_process_name(args.pid_or_name, config=config, host=host)
+            deluder = Deluder.for_existing_process_name(args.pid_or_name, remote_host=remote_host, config=config)
 
     # Run deluder
     deluder.delude()


### PR DESCRIPTION
Gives Deluder the ability to connect to an existing process in a remote host running frida-server.

Useful if Deluder cannot be installed in the target host (like ARM64 at the moment).